### PR TITLE
Refactor disciplina config interface for new YAML parser

### DIFF
--- a/deployments/cluster/educator.nix
+++ b/deployments/cluster/educator.nix
@@ -15,7 +15,7 @@ in
   );
 
   networking.firewall.allowedTCPPorts = [
-    4040 4041   # Witness ZMQ API
+    4010 4011   # Witness ZMQ API
     4030        # Witness HTTP Wallet API
     4040        # Educator HTTP API
   ];

--- a/deployments/cluster/educator.nix
+++ b/deployments/cluster/educator.nix
@@ -11,7 +11,7 @@ in
   ##
   # `map` to make additional SGs easier to add and SG list more readable
   deployment.ec2.securityGroupIds = map (x: resources.ec2SecurityGroups."cluster-${x}-sg".name ) (
-    [ "educator-api-private" "witness-api-private" ]
+    [ "educator-api-private" "witness-public" ]
   );
 
   networking.firewall.allowedTCPPorts = [

--- a/deployments/cluster/witness-load-balancer.nix
+++ b/deployments/cluster/witness-load-balancer.nix
@@ -65,7 +65,7 @@ in
       "${uris.educator}".locations."/".proxyPass = "http://educator";
       "${uris.explorer}".locations = {
         "/api".proxyPass = "http://witness";
-        "/".root = pkgs.disciplina-explorer-frontend;
+        "/".root = pkgs.disciplina-explorer-frontend.override { witnessUrl = "//${uris.witness}"; };
       };
 
       "${uris.faucet}".locations = {

--- a/deployments/cluster/witness-load-balancer.nix
+++ b/deployments/cluster/witness-load-balancer.nix
@@ -76,20 +76,26 @@ in
     };
   };
 
-  services.disciplina = {
+  services.disciplina = let
+    config-key = "alpha";
+
+  in rec {
     enable = true;
     type = "faucet";
+
+    config."${config-key}".faucet = {
+      appDir = "/var/lib/disciplina-${type}";
+      api.addr = "127.0.0.1:4014";
+      witnessBackend = "http://witness1:4030";
+      transferredAmount = 20;
+      keys = {
+        path = toString keys.faucet-key;
+        genNew = false;
+      };
+    };
+
     args = {
-      config = toString pkgs.disciplina-config;
-      config-key = "alpha";
-
-      appdir = "/var/lib/disciplina-faucet";
-
-      faucet-keyfile = keys.faucet-key;
-
-      faucet-listen = "127.0.0.1:4014";
-      translated-amount = "20";
-      witness-backend = "http://witness1:4030";
+      inherit config-key;
     };
   };
 }

--- a/deployments/cluster/witness.nix
+++ b/deployments/cluster/witness.nix
@@ -22,7 +22,7 @@ in
   deployment.ec2.elasticIPv4 = lib.mkIf (n == 0) (lib.mkForce "");
 
   networking.firewall.allowedTCPPorts = [
-    4040 4041   # Witness ZMQ API
+    4010 4011   # Witness ZMQ API
     4030        # Witness HTTP Wallet API
   ];
 

--- a/deployments/cluster/witness.nix
+++ b/deployments/cluster/witness.nix
@@ -46,7 +46,7 @@ in
     in {
       inherit config-key;
       bind = address (if isInternal then privateIP else publicIP);
-      bind-internal = address privateIP;
+      bind-internal = address "*";
       comm-n = toString n;
       comm-sec = cat keys.committee-secret;
       peer = map (node: address (if (hasInternalTag node) then node.config.networking.privateIPv4 else node.config.networking.publicIPv4))

--- a/deployments/cluster/witness.nix
+++ b/deployments/cluster/witness.nix
@@ -13,7 +13,9 @@ in
   # `map` to make additional SGs easier to add and SG list more readable
   deployment.ec2.securityGroupIds = map (x: resources.ec2SecurityGroups."cluster-${x}-sg".name ) (
     [ "witness-api-private" ] ++
-      (if isInternal then [ "witness-private" ] else [ "witness-public" ])
+    (if isInternal
+      then [ "witness-private" ]
+      else [ "witness-public" ])
   );
 
   ## We do not allocate an elastic IP for the internal witness node, so don't try to associate it
@@ -24,33 +26,31 @@ in
     4030        # Witness HTTP Wallet API
   ];
 
-  services.disciplina = {
+  services.disciplina = let
+    config-key = "alpha";
+
+  in rec {
     enable = true;
     type = "witness";
 
+    config."${config-key}".witness = rec {
+      appDir = "/var/lib/disciplina-${type}";
+      db.path = "${appDir}/witness.db";
+      api.addr = "0.0.0.0:4030";
+    };
+
     args = let
       cat = path: ''"$(cat "${path}")"'';
-      stateDir = "/var/lib/disciplina-witness";
-
-      publicIP = ''"$(curl "http://169.254.169.254/latest/meta-data/public-ipv4")"'';
-      privateIP = ''"$(curl "http://169.254.169.254/latest/meta-data/local-ipv4")"'';
+      publicIP = ''"$(curl "http://169.254.169.254/latest/meta-data/public-ipv4" 2>/dev/null)"'';
+      privateIP = ''"$(curl "http://169.254.169.254/latest/meta-data/local-ipv4" 2>/dev/null)"'';
     in {
+      inherit config-key;
       bind = address (if isInternal then privateIP else publicIP);
       bind-internal = address privateIP;
-
-      db-path = "${stateDir}/witness.db";
-
-      config-key = "alpha";
-
       comm-n = toString n;
       comm-sec = cat keys.committee-secret;
-
-      config = toString pkgs.disciplina-config;
-
       peer = map (node: address (if (hasInternalTag node) then node.config.networking.privateIPv4 else node.config.networking.publicIPv4))
         (attrValues (filterAttrs (name2: node: name != name2 && hasWitnessTag node) nodes));
-
-      witness-listen = "0.0.0.0:4030";
     };
   };
 

--- a/modules/services/disciplina.nix
+++ b/modules/services/disciplina.nix
@@ -69,6 +69,7 @@ in
       path = with pkgs; [ curl ];
 
       script = ''
+        set -euxo pipefail
         exec ${pkgs.disciplina}/bin/dscp-${cfg.type} --config ${cfg.upstreamConfigFile} --config ${mkConfig cfg.config} ${attrsToFlags cfg.args}
       '';
 


### PR DESCRIPTION
Some things can't be moved, because sections are sometimes parsed as a unit, and
the config itself is more verbose than necessary because many options lack sane
defaults.