### PR TITLE
Disable CI because it is broken

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
-steps:
-- command: nix-shell --run 'nix-build --no-out-link'
-  agents:
-    system: x86_64-linux
-  label: eval
+# steps:
+# - command: nix-shell --run 'nix-build --no-out-link'
+#   agents:
+#     system: x86_64-linux
+#   label: eval


### PR DESCRIPTION
Until CI is fixed, it is just misleading. Disable it until we fix it.