### PR TITLE
deployer: export cachix_name so arbitrary buildkite builds don't fail

### DIFF
--- a/deployments/deployer.nix
+++ b/deployments/deployer.nix
@@ -135,6 +135,7 @@ in {
         secrets="$(/run/wrappers/bin/sudo ${getBuildkiteSecrets})"
         export BUILDKITE_API_TOKEN=$(echo "$secrets" | jq -r .APIAccessToken)
         export CACHIX_SIGNING_KEY=$(echo "$secrets" | jq -r .CachixSigningKey)
+        export CACHIX_NAME=disciplina
         unset secrets
       '';
     };


### PR DESCRIPTION
Might argue that nix-with-cachix should check if this is set instead of CACHIX_SIGNING_KEY, but currently it fails if CACHIX_SIGNING_KEY is set but not CACHIX_NAME.