### PR TITLE
keys: Set service type = oneshot

### DIFF
--- a/modules/keys.nix
+++ b/modules/keys.nix
@@ -100,6 +100,7 @@
       after = requires;
       path = with pkgs; [ awscli jq ];
 
+      serviceConfig.Type = "oneshot";
       script = ''
         set -euo pipefail
         mkdir -p /run/keys


### PR DESCRIPTION
This fixes the race between populating the key file and reading it.