### PR TITLE
[OPS-698] Enable Postgres on educator

### DIFF
--- a/deployments/cluster/educator.nix
+++ b/deployments/cluster/educator.nix
@@ -20,7 +20,10 @@ in
     4040        # Educator HTTP API
   ];
 
-  services.postgresql.enable = true;
+  services.postgresql = {
+    enable = true;
+    package = pkgs.postgresql_9_6;
+  };
 
   services.disciplina = let
     config-key = "alpha";

--- a/deployments/cluster/educator.nix
+++ b/deployments/cluster/educator.nix
@@ -88,7 +88,7 @@ in
         (attrValues (filterAttrs (name2: node: name != name2 && hasWitnessTag node) nodes));
     };
 
-    after = [ "postgresql.service" ];
+    required = [ "postgresql.service" ];
     serviceConfig = {
       ExecStartPre =
         let

--- a/deployments/cluster/educator.nix
+++ b/deployments/cluster/educator.nix
@@ -91,7 +91,7 @@ in
         (attrValues (filterAttrs (name2: node: name != name2 && hasWitnessTag node) nodes));
     };
 
-    required = [ "postgresql.service" ];
+    requires = [ "postgresql.service" ];
     serviceConfig = {
       ExecStartPre =
         let

--- a/deployments/cluster/educator.nix
+++ b/deployments/cluster/educator.nix
@@ -24,6 +24,7 @@ in
     enable = true;
     authentication = ''
       host all postgres 127.0.0.1/32 trust
+      host all postgres ::1/128      trust
     '';
     initialScript =
       let

--- a/modules/services/disciplina.nix
+++ b/modules/services/disciplina.nix
@@ -50,6 +50,14 @@ in
         Set of arguments passed to witness CLI
       '';
     };
+
+    after = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = ''
+        Systemd services that this one has to be started after.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -62,7 +70,7 @@ in
     };
 
     systemd.services."disciplina-${cfg.type}" = rec {
-      after = [ "network.target" ];
+      after = [ "network.target" ] ++ cfg.after;
       requires = after;
       wantedBy = [ "multi-user.target" ];
 

--- a/modules/services/disciplina.nix
+++ b/modules/services/disciplina.nix
@@ -56,7 +56,7 @@ in
       default = [];
       description = ''
         Systemd services that this one depends on.
-        Will be added to Requires in After in the systemd unit.
+        Will be added to Requires and After in the systemd unit.
       '';
     };
 

--- a/modules/services/disciplina.nix
+++ b/modules/services/disciplina.nix
@@ -80,8 +80,8 @@ in
     };
 
     systemd.services."disciplina-${cfg.type}" = rec {
-      after = [ "network.target" ] ++ cfg.requires;
-      requires = after;
+      inherit (cfg) requires;
+      after = [ "network.target" ] ++ requires;
       wantedBy = [ "multi-user.target" ];
 
       path = with pkgs; [ curl ];

--- a/modules/services/disciplina.nix
+++ b/modules/services/disciplina.nix
@@ -58,6 +58,15 @@ in
         Systemd services that this one has to be started after.
       '';
     };
+
+    serviceConfig = mkOption {
+      default = {};
+      type = types.attrs;
+      description = ''
+        Systemd serviceConfig.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -85,7 +94,7 @@ in
         User = "disciplina";
         WorkingDirectory = stateDir;
         StateDirectory = "disciplina-${cfg.type}";
-      };
+      } // cfg.serviceConfig;
     };
   };
 }

--- a/modules/services/disciplina.nix
+++ b/modules/services/disciplina.nix
@@ -51,11 +51,12 @@ in
       '';
     };
 
-    after = mkOption {
+    requires = mkOption {
       type = types.listOf types.str;
       default = [];
       description = ''
-        Systemd services that this one has to be started after.
+        Systemd services that this one depends on.
+        Will be added to Requires in After in the systemd unit.
       '';
     };
 
@@ -79,7 +80,7 @@ in
     };
 
     systemd.services."disciplina-${cfg.type}" = rec {
-      after = [ "network.target" ] ++ cfg.after;
+      after = [ "network.target" ] ++ cfg.requires;
       requires = after;
       wantedBy = [ "multi-user.target" ];
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -12,7 +12,8 @@ in {
     inherit (previous) nixops;
   };
 
-  inherit (import <disciplina/release.nix> {}) disciplina-config disciplina;
+  inherit (import <disciplina/release.nix> {})
+    disciplina-config disciplina-data disciplina disciplina-educator;
   disciplina-faucet-frontend = callPackage <disciplina-faucet-frontend/release.nix> {};
   disciplina-explorer-frontend = callPackage <disciplina-explorer-frontend/release.nix> {};
   disciplina-validatorcv = callPackage <disciplina-validatorcv/release.nix> {};


### PR DESCRIPTION
This PR is WIP because the Educator fails to start and freezes for unknown reasons, but it seems that the issue is not related to any of these changes. See https://issues.serokell.io/issue/DSCP-468.
This PR depends on DisciplinaOU/disciplina#373.

* Enable postgresql service
* Fix educator db config structure
* Configure educator to use local postgres
* Add systemd dependency