### PR TITLE
Run CI when a target repository is private

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ are used:
 - `<env>/disciplina/cluster` is used by the cluster. It should be a JSON object
   containing the following keys: `CommitteeSecret` and `FaucetKey`.
 - `<env>/disciplina/buildkite` is used by the buildkite agent. It should be a
-  JSON object containing the following keys: `AgentToken`, `APIAccessToken` and
-  `CachixSigningKey`.
+  JSON object containing the following keys: `AgentToken`, `APIAccessToken`,
+  `CachixSigningKey` and `BuildkiteSSHKeys`. `BuildkiteSSHKeys` is an object
+  where keys are names of buildkite agents (e. g. `default`), and values are
+  private SSH RSA keys used by those agents.
 
 ## Setting up continuous delivery
 

--- a/deployments/darwin-builder.nix
+++ b/deployments/darwin-builder.nix
@@ -35,6 +35,7 @@ in
       tags.system = pkgs.system;
       runtimePackages = with pkgs; [ bash gnutar nix-with-cachix ];
       tokenPath = "${secrets}/buildkite-token";
+      sshKeyPath = "${secrets}/buildkite_darwin_rsa";
 
       # TODO: move to nix-darwin
       extraConfig = ''

--- a/deployments/darwin-builder.nix
+++ b/deployments/darwin-builder.nix
@@ -35,7 +35,10 @@ in
       tags.system = pkgs.system;
       runtimePackages = with pkgs; [ bash gnutar nix-with-cachix ];
       tokenPath = "${secrets}/buildkite-token";
-      sshKeyPath = "${secrets}/buildkite_darwin_rsa";
+      openssh = {
+        publicKeyPath = "${secrets}/buildkite_darwin_rsa.pub";
+        privateKeyPath = "${secrets}/buildkite_darwin_rsa";
+      };
 
       # TODO: move to nix-darwin
       extraConfig = ''

--- a/deployments/deployer.nix
+++ b/deployments/deployer.nix
@@ -92,7 +92,7 @@ in {
       associatePublicIpAddress = true;
       subnetId = vpcSubnets.deployer-subnet;
       securityGroupIds = with ec2SecurityGroups;
-        [ ssh-public-sg.name ];
+        [ ssh-public-sg.name mosh-public-sg.name ];
     };
 
     deployment.route53 = {
@@ -154,6 +154,9 @@ in {
         unset secrets
       '';
     };
+
+    # Enables `mosh` for more comfortable connection to deployer via SSH
+    programs.mosh.enable = true;
 
     users.extraGroups.nixops = {};
     users.mutableUsers = false;

--- a/deployments/deployer.nix
+++ b/deployments/deployer.nix
@@ -31,11 +31,7 @@ let
   '';
 
   buildkiteAgentName = "default";
-  getBuildkiteSecrets = pkgs.writeScript "getBuildkiteSecrets" ''
-    #!${pkgs.bash}/bin/bash
-    ${pkgs.awscli}/bin/aws secretsmanager get-secret-value --secret-id production/disciplina/buildkite --region eu-central-1 \
-      | ${pkgs.jq}/bin/jq -r .SecretString
-  '';
+  buildkiteAgentUserName = "buildkite-agent-${buildkiteAgentName}";
 
   nixopsWrapper =
   let
@@ -80,6 +76,8 @@ in {
   require = [ ./shared-resources.nix ];
 
   deployer = { config, name, resources, ... }: {
+    imports = [ ../modules ];
+
     deployment.targetEnv = "ec2";
 
     deployment.ec2 = with resources; {
@@ -130,7 +128,22 @@ in {
 
     nixpkgs.pkgs = pkgs;
 
-    services.buildkite-agents.${buildkiteAgentName} = {
+    awskeys =
+    let
+      buildkiteKeyCommon = {
+        inherit region;
+        user = buildkiteAgentUserName;
+        services = [ buildkiteAgentUserName ];
+        secretId = "production/disciplina/buildkite";
+      };
+    in {
+      agent-token        = buildkiteKeyCommon // { key = "AgentToken"; };
+      api-access-token   = buildkiteKeyCommon // { key = "APIAccessToken"; };
+      cachix-signing-key = buildkiteKeyCommon // { key = "CachixSigningKey"; };
+      buildkite-ssh-key  = buildkiteKeyCommon // { key = "BuildkiteSSHKeys.${buildkiteAgentName}"; };
+    };
+
+    services.buildkite-agents.${buildkiteAgentName} = let keys = config.awskeys; in {
       enable = env != "bootstrap";
 
       runtimePackages = with pkgs; [ bash gnutar nix-with-cachix jq ];
@@ -138,18 +151,12 @@ in {
       tags.hostname = config.networking.hostName;
       tags.system = pkgs.system;
 
-      # tokenPath is cat'd into the buildkite config file, as root
-      # https://github.com/serokell/nixpkgs/blob/e68ada3bfc8142ca94526cd5f39fcc58e57b85a4/nixos/modules/services/continuous-integration/buildkite-agents.nix#L258
-      # token="$(cat ${toString cfg.tokenPath})"
-      # but there is a check that it is a path (starts with a /)
-      # long-term, we should probably add a tokenCommand
-      tokenPath = "/dev/null <(${getBuildkiteSecrets} | jq -r .AgentToken)";
-      # :)
+      tokenPath = toString keys.agent-token;
+      sshKeyPath = toString keys.buildkite-ssh-key;
 
       hooks.environment = ''
-        secrets="$(/run/wrappers/bin/sudo ${getBuildkiteSecrets})"
-        export BUILDKITE_API_TOKEN=$(echo "$secrets" | jq -r .APIAccessToken)
-        export CACHIX_SIGNING_KEY=$(echo "$secrets" | jq -r .CachixSigningKey)
+        export BUILDKITE_API_TOKEN=$(cat ${toString keys.api-access-token})
+        export CACHIX_SIGNING_KEY=$(cat ${toString keys.cachix-signing-key})
         export CACHIX_NAME=disciplina
         unset secrets
       '';
@@ -199,14 +206,6 @@ in {
           ];
           runAs = "root";
           users = [ "nixops" ];
-        }
-        {
-          commands = [
-            { command = toString getBuildkiteSecrets;
-              options = [ "NOSETENV" "NOPASSWD" ]; }
-          ];
-          runAs = "root";
-          users = [ "buildkite-agent-${buildkiteAgentName}" ];
         }
       ];
       extraConfig = ''

--- a/deployments/lib.nix
+++ b/deployments/lib.nix
@@ -28,6 +28,14 @@ rec {
   # DSL to declare Security Groups.
   sg = vpc: {
 
+    # Declare an SG that accepts connections from ranges of ports
+    publicRanges = ranges: (withVPC vpc {
+      rules = map
+        ({ from, to, protocol ? "tcp" }:
+         { toPort = to; fromPort = from; protocol = protocol; sourceIp = "0.0.0.0/0"; }
+        ) ranges;
+    });
+
     # Declare an SG that accepts connections from anywhere
     public = ports: (withVPC vpc {
       rules = map (x: { toPort = x; fromPort = x; sourceIp = "0.0.0.0/0"; }) ports;

--- a/deployments/shared-resources.nix
+++ b/deployments/shared-resources.nix
@@ -25,6 +25,7 @@ in
 
     ec2SecurityGroups = with sg "shared-vpc"; {
       ssh-public-sg         = public [ 22 ];
+      mosh-public-sg        = publicRanges [{ from = 60000; to = 61000; protocol = "udp"; }];
     };
   };
 }


### PR DESCRIPTION
Adds support of SSH keys to buildkite agents. Also, adds `mosh` to deployer for convenience.